### PR TITLE
updates grammar to fix an issue in concise syntax

### DIFF
--- a/Syntaxes/Marko.tmLanguage
+++ b/Syntaxes/Marko.tmLanguage
@@ -2272,7 +2272,7 @@
 			<key>applyEndPatternLast</key>
 			<integer>1</integer>
 			<key>begin</key>
-			<string>^(\s*)(script)(?=(\s|$|\())</string>
+			<string>^(\s*)(script)(?!(.*\ssrc=".*"))(?=(\s|$|\())</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>2</key>

--- a/test-templates/concise.marko
+++ b/test-templates/concise.marko
@@ -2,6 +2,7 @@
 html lang="en"
     head
         title - Marko Templating Engine
+		script src="https://www.marko.com/marko.js" type="text/javascript"
 		script
 			---
 			var i = 1+2;

--- a/test-templates/scratch.marko
+++ b/test-templates/scratch.marko
@@ -6,6 +6,9 @@ script
 	
 script -- console.log('Hello');
 
+script src="htts://www.marko.com/marko.2341.js?x=%2045|03942"
+    -- { test: 'foo' } console.log('Hello');
+
 script
 	--
 	console.log('Hello');


### PR DESCRIPTION
It looks like, when using the .tmLanguage in SublimeText, there is an issue in the concise syntax highlighter that makes it act as if a script tag w/ a `src` attribute will have a js body.  I have updated the templates for testing this and the concise script grammar to do a negative-lookahead for the `src` attribute.

I'm not too familiar with concise syntax, so please let me know if there's something I might have missed.  If this is merged here, I will then update the sublime-marko package, since I'd rather not deviate from what is in this repository when it comes to the grammar.

This issue was raised by a user of sublime-marko here: https://github.com/merwan7/sublime-marko/issues/5